### PR TITLE
Refactor: Treat local store as a cache, never overwriting DB on sync

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,3 +44,40 @@ export function debounce<T extends (...args: unknown[]) => unknown>(
     timeout = setTimeout(later, wait);
   };
 }
+
+export function deepEqual(obj1: unknown, obj2: unknown): boolean {
+  const seen = new WeakMap<object, object>();
+  function inner(a: unknown, b: unknown): boolean {
+    // primitive / reference
+    if (a === b) return true;
+    if (a == null || b == null || typeof a !== "object" || typeof b !== "object") return false;
+
+    if (seen.get(a as object) === b) return true;
+    seen.set(a as object, b as object);
+
+    if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) return false;
+
+    // Handle built-ins that need value-level equality
+    if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+    if (a instanceof RegExp && b instanceof RegExp)
+      return a.source === b.source && a.flags === b.flags;
+    if (a instanceof Map && b instanceof Map)
+      return a.size === b.size && [...a.entries()].every(([k, v]) => b.has(k) && inner(v, b.get(k)));
+    if (a instanceof Set && b instanceof Set)
+      return a.size === b.size && [...a].every(v => b.has(v));
+
+    const keysA = Reflect.ownKeys(a as object);
+    const keysB = Reflect.ownKeys(b as object);
+    if (keysA.length !== keysB.length) return false;
+
+    return keysA.every(key =>
+      keysB.includes(key) &&
+      inner(
+        (a as Record<PropertyKey, unknown>)[key],
+        (b as Record<PropertyKey, unknown>)[key]
+      )
+    );
+  }
+
+  return inner(obj1, obj2);
+}

--- a/src/services/SyncManager.ts
+++ b/src/services/SyncManager.ts
@@ -16,18 +16,7 @@ export class SyncManager<Local> {
    * @param since ISO timestamp to filter remote updates (inclusive)
    */
   async sync(userId: string, localItems: Local[], since?: string): Promise<Local[]> {
-    // upsert local items
-    if (localItems.length) {
-      await retryWithBackoff(async () => {
-        const payload = localItems.map(item => this.cfg.mapLocal(item, userId));
-        const { error } = await this.supabase
-          .from(this.cfg.table)
-          .upsert(payload, { onConflict: "id" });
-        if (error) throw error;
-      });
-    }
-
-    // fetch remote items (optionally incremental)
+    // 1. Fetch remote items (optionally incremental) - (existing code)
     let query = this.supabase
       .from(this.cfg.table)
       .select("*")
@@ -35,18 +24,37 @@ export class SyncManager<Local> {
     if (since && this.cfg.updatedAtColumn) {
       query = query.gt(this.cfg.updatedAtColumn, since);
     }
-    const { data: rows, error } = await query;
-    if (error) throw error;
-    const remoteRows = rows || [];
+    const { data: remoteRowsData, error: fetchError } = await query;
+    if (fetchError) throw fetchError; // Propagate fetch errors
 
-    // map rows to Local
+    const remoteRows = remoteRowsData || [];
     const remoteItems = (remoteRows as any[]).map(r => this.cfg.mapRow(r));
-
-    // detect local-only items
     const remoteIds = new Set(remoteItems.map((item: any) => (item as any).id));
-    const localOnly = localItems.filter(item => !remoteIds.has((item as any).id));
 
-    return [...remoteItems, ...localOnly];
+    // 2. Detect local-only items (items in input localItems not present in remoteItems)
+    const localOnlyItems = localItems.filter(item => !remoteIds.has((item as any).id));
+
+    // 3. Insert local-only items into the remote database
+    if (localOnlyItems.length) {
+      await retryWithBackoff(async () => {
+        const payload = localOnlyItems.map(item => this.cfg.mapLocal(item, userId));
+        const { error: insertError } = await this.supabase
+          .from(this.cfg.table)
+          .insert(payload); // Use insert for new items
+
+        if (insertError) {
+          // Log error and continue, as primary goal is to refresh cache from server.
+          // These items might get reconciled in a future sync or by specific user actions.
+          console.warn(`[SyncManager] Error inserting local-only items for table ${this.cfg.table}: ${insertError.message}. Items:`, localOnlyItems);
+          // Do not throw here, allow sync to proceed with fetched remote items
+        }
+      });
+    }
+
+    // 4. Return remote items and the original local-only items for cache update
+    // The local cache will be updated with what's on the server + new items created locally.
+    // If an insert failed, the local-only item remains in the cache and might be retried next sync.
+    return [...remoteItems, ...localOnlyItems];
   }
 
   subscribe(

--- a/src/services/SyncManager.ts
+++ b/src/services/SyncManager.ts
@@ -1,14 +1,18 @@
 import type { SupabaseClient, RealtimeChannel } from "@supabase/supabase-js";
 import { retryWithBackoff } from "./noteService";
 
-export interface SyncConfig<Local> {
+export interface Identifiable {
+  id: string;
+}
+
+export interface SyncConfig<Local extends Identifiable> {
   table: string;
   mapRow: (row: any) => Local;
   mapLocal: (item: Local, userId: string) => Record<string, unknown>;
   updatedAtColumn?: string;
 }
 
-export class SyncManager<Local> {
+export class SyncManager<Local extends Identifiable> {
   constructor(private supabase: SupabaseClient, private cfg: SyncConfig<Local>) {}
 
   /**
@@ -28,11 +32,11 @@ export class SyncManager<Local> {
     if (fetchError) throw fetchError; // Propagate fetch errors
 
     const remoteRows = remoteRowsData || [];
-    const remoteItems = (remoteRows as any[]).map(r => this.cfg.mapRow(r));
-    const remoteIds = new Set(remoteItems.map((item: any) => (item as any).id));
+    const remoteItems = remoteRows.map(r => this.cfg.mapRow(r));
+    const remoteIds = new Set(remoteItems.map(item => item.id));
 
     // 2. Detect local-only items (items in input localItems not present in remoteItems)
-    const localOnlyItems = localItems.filter(item => !remoteIds.has((item as any).id));
+    const localOnlyItems = localItems.filter(item => !remoteIds.has(item.id));
 
     // 3. Insert local-only items into the remote database
     if (localOnlyItems.length) {

--- a/src/services/SyncManager.ts
+++ b/src/services/SyncManager.ts
@@ -85,8 +85,8 @@ export class SyncManager<Local extends Identifiable> {
         
         // Use deep equality check instead of JSON.stringify for accurate object comparison
         if (!deepEqual(localWithoutTs, remoteWithoutTs)) {
-          // Default to local being newer if timestamps are not available or invalid
-          const localTimeRaw = localUpdatedAt ? new Date(localUpdatedAt).getTime() : Number.MAX_SAFE_INTEGER;
+          // Default to treating items with missing timestamps as older than any item with a valid timestamp
+          const localTimeRaw = localUpdatedAt ? new Date(localUpdatedAt).getTime() : Number.NEGATIVE_INFINITY;
           const localTime = Number.isNaN(localTimeRaw) ? Number.NEGATIVE_INFINITY : localTimeRaw;
           const remoteTimeRaw = remoteUpdatedAt ? new Date(remoteUpdatedAt).getTime() : Number.NEGATIVE_INFINITY;
           const remoteTime = Number.isFinite(remoteTimeRaw) ? remoteTimeRaw : Number.NEGATIVE_INFINITY;

--- a/src/services/SyncManager.ts
+++ b/src/services/SyncManager.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient, RealtimeChannel } from "@supabase/supabase-js";
 import { retryWithBackoff } from "./noteService";
+import { deepEqual } from "@/lib/utils";
 
 export interface Identifiable {
   id: string;
@@ -10,6 +11,11 @@ export interface SyncConfig<Local extends Identifiable> {
   mapRow: (row: any) => Local;
   mapLocal: (item: Local, userId: string) => Record<string, unknown>;
   updatedAtColumn?: string;
+  /**
+   * Page size for fetching records. Defaults to 1000.
+   * Adjust based on your record size and performance needs.
+   */
+  pageSize?: number;
 }
 
 export class SyncManager<Local extends Identifiable> {
@@ -20,40 +26,100 @@ export class SyncManager<Local extends Identifiable> {
    * @param since ISO timestamp to filter remote updates (inclusive)
    */
   async sync(userId: string, localItems: Local[], since?: string): Promise<Local[]> {
-    // 1. Fetch remote items (optionally incremental) - (existing code)
-    let query = this.supabase
-      .from(this.cfg.table)
-      .select("*")
-      .eq("user_id", userId);
-    if (since && this.cfg.updatedAtColumn) {
-      query = query.gt(this.cfg.updatedAtColumn, since);
+    // 1. Fetch remote items with incremental sync support
+    const pageSize = this.cfg.pageSize || 1000;
+    let cursor = since ?? undefined;
+    let allRemoteRows: any[] = [];
+
+    while (true) {
+      const updatedCol = this.cfg.updatedAtColumn || 'updated_at';
+      let query = this.supabase
+        .from(this.cfg.table)
+        .select('*')
+        .eq('user_id', userId)
+        .order(updatedCol, { ascending: true })
+        .limit(pageSize);
+
+      if (cursor) {
+        query = query.gt(updatedCol, cursor);
+      }
+
+      const { data: pageData, error: fetchError } = await query;
+
+      if (fetchError) throw fetchError;
+
+      if (!pageData || pageData.length === 0) {
+        break; // No more data
+      }
+
+      allRemoteRows = [...allRemoteRows, ...pageData];
+
+      // Update cursor for the next page
+      cursor = pageData[pageData.length - 1][updatedCol];
+
+      // If we got fewer items than requested, we've reached the end
+      if (pageData.length < pageSize) {
+        break;
+      }
     }
-    const { data: remoteRowsData, error: fetchError } = await query;
-    if (fetchError) throw fetchError; // Propagate fetch errors
 
-    const remoteRows = remoteRowsData || [];
+    const remoteRows = allRemoteRows;
     const remoteItems = remoteRows.map(r => this.cfg.mapRow(r));
-    const remoteIds = new Set(remoteItems.map(item => item.id));
+    const remoteMap = new Map(remoteItems.map(item => [item.id, item]));
+    const localMap = new Map(localItems.map(item => [item.id, item]));
 
-    // 2. Detect local-only items (items in input localItems not present in remoteItems)
-    const localOnlyItems = localItems.filter(item => !remoteIds.has(item.id));
+    // 2. Categorize items
+    const localOnlyItems: Local[] = [];
+    const remoteOnlyItems: Local[] = [];
+    const modifiedItems: { local: Local; remote: Local; isLocalNewer: boolean }[] = [];
 
-    // 3. Insert local-only items into the remote database
-    if (localOnlyItems.length) {
+    // Check local items first
+    for (const localItem of localItems) {
+      const remoteItem = remoteMap.get(localItem.id);
+      if (!remoteItem) {
+        localOnlyItems.push(localItem);
+      } else {
+        // Check if local item is modified by comparing content, not just timestamps
+        const { [this.cfg.updatedAtColumn || 'updatedAt']: localUpdatedAt, ...localWithoutTs } = localItem as any;
+        const { [this.cfg.updatedAtColumn || 'updatedAt']: remoteUpdatedAt, ...remoteWithoutTs } = remoteItem as any;
+        
+        // Use deep equality check instead of JSON.stringify for accurate object comparison
+        if (!deepEqual(localWithoutTs, remoteWithoutTs)) {
+          // Default to local being newer if timestamps are not available or invalid
+          const localTimeRaw = localUpdatedAt ? new Date(localUpdatedAt).getTime() : Number.MAX_SAFE_INTEGER;
+          const localTime = Number.isNaN(localTimeRaw) ? Number.NEGATIVE_INFINITY : localTimeRaw;
+          const remoteTimeRaw = remoteUpdatedAt ? new Date(remoteUpdatedAt).getTime() : Number.NEGATIVE_INFINITY;
+          const remoteTime = Number.isFinite(remoteTimeRaw) ? remoteTimeRaw : Number.NEGATIVE_INFINITY;
+          const isLocalNewer = localTime > remoteTime;
+          
+          modifiedItems.push({ 
+            local: localItem, 
+            remote: remoteItem,
+            isLocalNewer
+          });
+        }
+      }
+    }
+
+    // Find remote-only items
+    for (const remoteItem of remoteItems) {
+      if (!localMap.has(remoteItem.id)) {
+        remoteOnlyItems.push(remoteItem);
+      }
+    }
+
+    // 3. Handle local-only items (new items)
+    if (localOnlyItems.length > 0) {
       try {
         await retryWithBackoff(async () => {
           const payload = localOnlyItems.map(item => this.cfg.mapLocal(item, userId));
           const { error: insertError } = await this.supabase
             .from(this.cfg.table)
-            .insert(payload); // Use insert for new items
+            .insert(payload);
 
-          if (insertError) {
-            // Let retryWithBackoff handle retries.
-            throw insertError;
-          }
+          if (insertError) throw insertError;
         });
       } catch (insertError) {
-        // All retries exhausted – keep going but surface the issue for observability.
         console.warn(
           `[SyncManager] Failed to insert local-only items for table ${this.cfg.table} after retries: ${(insertError as Error).message}`,
           localOnlyItems
@@ -61,10 +127,60 @@ export class SyncManager<Local extends Identifiable> {
       }
     }
 
-    // 4. Return remote items and the original local-only items for cache update
-    // The local cache will be updated with what's on the server + new items created locally.
-    // If an insert failed, the local-only item remains in the cache and might be retried next sync.
-    return [...remoteItems, ...localOnlyItems];
+    // 4. Handle modified items with conflict resolution
+    if (modifiedItems.length > 0) {
+      try {
+        await retryWithBackoff(async () => {
+          const updates = [];
+          const now = new Date().toISOString();
+          
+          for (const { local, remote, isLocalNewer } of modifiedItems) {
+            // Only update if local changes are actually newer or if there are content changes
+            if (isLocalNewer) {
+              const updateData = this.cfg.mapLocal(local, userId);
+              // Ensure updated_at is set to now for the last-write-wins strategy
+              if (this.cfg.updatedAtColumn) {
+                updateData[this.cfg.updatedAtColumn] = now;
+                // Also update the local object's timestamp to match
+                (local as any)[this.cfg.updatedAtColumn] = now;
+              }
+              updates.push(updateData);
+            }
+          }
+
+          if (updates.length > 0) {
+            const { error: updateError } = await this.supabase
+              .from(this.cfg.table)
+              .upsert(updates, { onConflict: 'id' });
+
+            if (updateError) throw updateError;
+          }
+        });
+      } catch (updateError) {
+        console.warn(
+          `[SyncManager] Failed to update modified items for table ${this.cfg.table}: ${(updateError as Error).message}`,
+          modifiedItems
+        );
+      }
+    }
+
+    // 5. Return combined results including unchanged items
+    const mergedItems = [...remoteOnlyItems, ...localOnlyItems];
+    
+    // Add modified items (either local or remote version)
+    for (const { local, remote, isLocalNewer } of modifiedItems) {
+      mergedItems.push(isLocalNewer ? local : remote);
+    }
+    
+    // Add unchanged items (present in both local and remote but with identical content)
+    const processedIds = new Set(mergedItems.map(item => item.id));
+    for (const remoteItem of remoteItems) {
+      if (!processedIds.has(remoteItem.id)) {
+        mergedItems.push(remoteItem);
+      }
+    }
+    
+    return mergedItems;
   }
 
   subscribe(

--- a/src/services/SyncManager.ts
+++ b/src/services/SyncManager.ts
@@ -36,19 +36,25 @@ export class SyncManager<Local> {
 
     // 3. Insert local-only items into the remote database
     if (localOnlyItems.length) {
-      await retryWithBackoff(async () => {
-        const payload = localOnlyItems.map(item => this.cfg.mapLocal(item, userId));
-        const { error: insertError } = await this.supabase
-          .from(this.cfg.table)
-          .insert(payload); // Use insert for new items
+      try {
+        await retryWithBackoff(async () => {
+          const payload = localOnlyItems.map(item => this.cfg.mapLocal(item, userId));
+          const { error: insertError } = await this.supabase
+            .from(this.cfg.table)
+            .insert(payload); // Use insert for new items
 
-        if (insertError) {
-          // Log error and continue, as primary goal is to refresh cache from server.
-          // These items might get reconciled in a future sync or by specific user actions.
-          console.warn(`[SyncManager] Error inserting local-only items for table ${this.cfg.table}: ${insertError.message}. Items:`, localOnlyItems);
-          // Do not throw here, allow sync to proceed with fetched remote items
-        }
-      });
+          if (insertError) {
+            // Let retryWithBackoff handle retries.
+            throw insertError;
+          }
+        });
+      } catch (insertError) {
+        // All retries exhausted – keep going but surface the issue for observability.
+        console.warn(
+          `[SyncManager] Failed to insert local-only items for table ${this.cfg.table} after retries: ${(insertError as Error).message}`,
+          localOnlyItems
+        );
+      }
     }
 
     // 4. Return remote items and the original local-only items for cache update


### PR DESCRIPTION
I've modified `SyncManager.sync` to prevent the automatic upsert of all local items during the sync process. Now, sync primarily fetches remote changes to update the local cache.

New, locally-created items (not yet in the database) are identified as 'localOnlyItems' and are inserted into the database during the sync. Existing items that have local modifications will not have those modifications pushed to the server via the main sync operation; instead, the server's version will refresh the local cache.

This change ensures that the database remains the source of truth and the local store acts as a cache, updated by server changes either through full sync or realtime updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced incremental pagination for remote data fetching during synchronization.
	- Added deep equality checks to accurately detect modified items.
- **Bug Fixes**
	- Improved synchronization reliability by ensuring local-only items are inserted into the remote database after fetching remote data, with errors handled gracefully to allow partial sync completion.
- **Chores**
	- Enhanced sync process to better merge local and remote items, reducing the chance of sync interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->